### PR TITLE
Fix CI build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,17 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - name: Setup dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev libxi-dev libxtst-dev pkg-config
+          echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> "$GITHUB_ENV"
+      - name: Setup dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install pkg-config
+      - name: Setup dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: choco install pkgconfiglite -y
       - run: cargo build --verbose --examples
       - run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
 rdev = "0.5"
 once_cell = "1"

--- a/examples/linux.rs
+++ b/examples/linux.rs
@@ -1,6 +1,13 @@
+#[cfg(target_os = "linux")]
 use recaret::platform::linux;
 
+#[cfg(target_os = "linux")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     linux::start().await
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("This example only runs on Linux.");
 }

--- a/examples/macos.rs
+++ b/examples/macos.rs
@@ -1,6 +1,13 @@
+#[cfg(target_os = "macos")]
 use recaret::platform::macos;
 
+#[cfg(target_os = "macos")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     macos::start().await
+}
+
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    eprintln!("This example only runs on macOS.");
 }

--- a/examples/windows.rs
+++ b/examples/windows.rs
@@ -1,6 +1,13 @@
+#[cfg(target_os = "windows")]
 use recaret::platform::windows;
 
+#[cfg(target_os = "windows")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     windows::start().await
+}
+
+#[cfg(not(target_os = "windows"))]
+fn main() {
+    eprintln!("This example only runs on Windows.");
 }


### PR DESCRIPTION
## Summary
- enable Tokio `sync` feature for mutex/mpsc usage
- gate examples to compile only on their target OS

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6849760609508328a9ed5af9cf0d024f